### PR TITLE
Set minimum Python version to 3.9

### DIFF
--- a/pathcrawler/utils.py
+++ b/pathcrawler/utils.py
@@ -39,7 +39,7 @@ def updateHashmap(hashmap: dict, files: list) -> Union[dict, bool]:
             if not hashstr:
                 if gs.VERBOSITY_LEVEL > 0:
                     print("Warning: File not found")
-                    print("\t", str(element), "could be missing reference link")
+                    print("\t", str(path), "could be missing reference link")
                 continue
             hashmap, de = appendHashmap(hashmap, hashstr, path)
             duplicatesExist = duplicatesExist or de

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from distutils.core import setup
 
 setup(
-   name='PathCrawler', 
+   name='PathCrawler',
    version='1.1',
    packages=['pathcrawler',],
-   license='MIT', 
+   license='MIT',
+   python_requires='>=3.9',
    long_description=open('README.md').read(),
    long_description_content_type='text/markdown'
 )


### PR DESCRIPTION
Python 3.9 is a requirement for `Path.readlink()`.